### PR TITLE
Changes to make User owned Org repositories included in Top Languages calculation

### DIFF
--- a/api/status/up.js
+++ b/api/status/up.js
@@ -22,7 +22,7 @@ export const RATE_LIMIT_SECONDS = 60 * 5; // 1 request per 5 minutes
  * @param {string} token GitHub token.
  * @returns {Promise<AxiosResponse>} The response.
  */
-const uptimeFetcher = (variables, token) => {
+const uptimeFetcher = (variables, opts, token) => {
   return request(
     {
       query: `

--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -32,6 +32,7 @@ export default async (req, res) => {
     border_color,
     disable_animations,
     hide_progress,
+    include_owned_orgs,
   } = req.query;
   res.setHeader("Content-Type", "image/svg+xml");
 
@@ -65,6 +66,7 @@ export default async (req, res) => {
     const topLangs = await fetchTopLanguages(
       username,
       parseArray(exclude_repo),
+      { include_owned_orgs },
       size_weight,
       count_weight,
     );

--- a/src/fetchers/gist-fetcher.js
+++ b/src/fetchers/gist-fetcher.js
@@ -37,9 +37,10 @@ query gistInfo($gistName: String!) {
  *
  * @param {AxiosRequestHeaders} variables Fetcher variables.
  * @param {string} token GitHub token.
+ * @param {object} opts Optional Configuration Options
  * @returns {Promise<AxiosResponse>} The response.
  */
-const fetcher = async (variables, token) => {
+const fetcher = async (variables, opts, token) => {
   return await request(
     { query: QUERY, variables },
     { Authorization: `token ${token}` },

--- a/src/fetchers/repo-fetcher.js
+++ b/src/fetchers/repo-fetcher.js
@@ -14,7 +14,7 @@ import { MissingParamError, request } from "../common/utils.js";
  * @param {string} token GitHub token.
  * @returns {Promise<AxiosResponse>} The response.
  */
-const fetcher = (variables, token) => {
+const fetcher = (variables, opts, token) => {
   return request(
     {
       query: `

--- a/src/fetchers/stats-fetcher.js
+++ b/src/fetchers/stats-fetcher.js
@@ -86,9 +86,10 @@ const GRAPHQL_STATS_QUERY = `
  *
  * @param {object} variables Fetcher variables.
  * @param {string} token GitHub token.
+ * @param {object} opts Optional Configuration Options
  * @returns {Promise<AxiosResponse>} Axios response.
  */
-const fetcher = (variables, token) => {
+const fetcher = (variables, opts, token) => {
   const query = variables.after ? GRAPHQL_REPOS_QUERY : GRAPHQL_STATS_QUERY;
   return request(
     {
@@ -174,7 +175,7 @@ const totalCommitsFetcher = async (username) => {
   }
 
   // https://developer.github.com/v3/search/#search-commits
-  const fetchTotalCommits = (variables, token) => {
+  const fetchTotalCommits = (variables, opts, token) => {
     return axios({
       method: "get",
       url: `https://api.github.com/search/commits?q=author:${variables.login}`,

--- a/tests/fetchTopLanguages.test.js
+++ b/tests/fetchTopLanguages.test.js
@@ -64,7 +64,7 @@ describe("FetchTopLanguages", () => {
   it("should fetch correct language data while using the new calculation", async () => {
     mock.onPost("https://api.github.com/graphql").reply(200, data_langs);
 
-    let repo = await fetchTopLanguages("anuraghazra", [], 0.5, 0.5);
+    let repo = await fetchTopLanguages("anuraghazra", [], {}, 0.5, 0.5);
     expect(repo).toStrictEqual({
       HTML: {
         color: "#0f0",
@@ -104,7 +104,7 @@ describe("FetchTopLanguages", () => {
   it("should fetch correct language data while using the old calculation", async () => {
     mock.onPost("https://api.github.com/graphql").reply(200, data_langs);
 
-    let repo = await fetchTopLanguages("anuraghazra", [], 1, 0);
+    let repo = await fetchTopLanguages("anuraghazra", [], {}, 1, 0);
     expect(repo).toStrictEqual({
       HTML: {
         color: "#0f0",
@@ -124,7 +124,7 @@ describe("FetchTopLanguages", () => {
   it("should rank languages by the number of repositories they appear in", async () => {
     mock.onPost("https://api.github.com/graphql").reply(200, data_langs);
 
-    let repo = await fetchTopLanguages("anuraghazra", [], 0, 1);
+    let repo = await fetchTopLanguages("anuraghazra", [], {}, 0, 1);
     expect(repo).toStrictEqual({
       HTML: {
         color: "#0f0",

--- a/tests/retryer.test.js
+++ b/tests/retryer.test.js
@@ -15,7 +15,7 @@ const fetcherFail = jest.fn(() => {
   );
 });
 
-const fetcherFailOnSecondTry = jest.fn((_vars, _token, retries) => {
+const fetcherFailOnSecondTry = jest.fn((_vars, _opts, _token, retries) => {
   return new Promise((res) => {
     // faking rate limit
     if (retries < 1) {


### PR DESCRIPTION
## Changes

* Option to make User owned Org repositories included in Top Languages calculation
* Added flag `include_owned_orgs` for top-langs api
* Privately hosted app will need token with org read permissions